### PR TITLE
Migrate to ulauncher extensions API v2

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import logging
 import json
 from ulauncher.api.client.Extension import Extension
@@ -23,15 +23,15 @@ class KeywordQueryEventListener(EventListener):
         searchKeyword = event.get_argument()
 
         if not searchKeyword:
-            return;
+            return
 
         url = 'https://api.npms.io/v2/search?q={}&size=5'.format(searchKeyword)
         logger.debug(url)
 
-        req = urllib2.Request(url)
+        req = urllib.request.Request(url)
         req.add_header('User-Agent', 'ulauncher-npms')
 
-        response = urllib2.urlopen(req)
+        response = urllib.request.urlopen(req)
         data = json.load(response)
 
         items = []

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-	"manifest_version": "1",
-	"api_version": "1",
+	"required_api_version": "^2.0.0",
 	"name": "npms",
 	"description": "Search for Javascript packages at npms.io.",
 	"developer_name": "Rolf Koenders",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "python2" },
+  { "required_api_version": "^2.0.0", "commit": "master" }
+]


### PR DESCRIPTION
Hey! :smile: 

Ulauncher extensions API was updated to v2, and extensions must be updated to work on the new version.
I upgraded `main.py` to Python 3, and updated `manifest.json` and `versions.json`.

You should then create a new branch named `python2`, containing the previous version of `master`, to support ulauncher users without the new version.

More infos can be found [here](http://docs.ulauncher.io/en/latest/extensions/migration.html#migrate-from-api-v1-to-v2-0-0)!

Closes #1